### PR TITLE
Persist user on reload

### DIFF
--- a/src/components/Dashboard/Statistics.js
+++ b/src/components/Dashboard/Statistics.js
@@ -3,10 +3,13 @@ import { getAuth, onAuthStateChanged } from "firebase/auth";
 import StatisticsCard from "./StatisticsCard";
 import { Oval } from 'react-loader-spinner';
 import { getEmissionStatistics } from "../../api/NoCO2_api";
+import { useNavigate } from 'react-router-dom';
 
 function Statistics() {
   const [statistics, setStatistics] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     const auth = getAuth();
@@ -30,13 +33,13 @@ function Statistics() {
         fetchData(user.uid);
       } else {
         // User is signed out, handle accordingly
-        console.log('User is signed out.');
+        navigate("/NoCO2/");
       }
     });
 
     // Clean up the event listener when the component is unmounted
     return () => unsubscribe();
-  }, []);
+  }, [navigate]);
 
   return (
     <div class="flex justify-center align-middle px-4 mb-4">

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
+import { getAuth, setPersistence, browserLocalPersistence } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -19,7 +20,13 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-initializeApp(firebaseConfig);
+const app = initializeApp(firebaseConfig);
+
+// Get Auth Instance
+const auth = getAuth(app);
+
+// Set local persistence for the auth instance
+setPersistence(auth, browserLocalPersistence);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
Currently when user logged in and navigate to dashboard or activity input form page, if the user reload the page, user is not persisted and no data will be retrieved.

Add local persist to firebase authentication and use onAuthStateChanged hook to get user id in retrieving user id from firebase.